### PR TITLE
With Alpine 3.19.0 -> 3.19.1, we no longer need to get jq from the "edge" repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
 FROM alpine:3.19.1@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
 
-# bash - v5.2.15-r5
-# bats - v1.9.0-r0
-RUN apk add --no-cache bash bats
-
-# jq   - v1.7-r2
-RUN apk add --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/edge/main jq
+# bash - v5.2.21-r0
+# bats - v1.10.0-r0
+# jq   - v1.7.1-r0
+RUN apk add --no-cache bash bats jq
 
 WORKDIR /opt/test-runner
 COPY . .


### PR DESCRIPTION
jq v1.7 has been incorporated into the main package repo. 
bash and bats both get version bumps.