### PR TITLE
Update tool version comments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM alpine:3.21.2@sha256:56fa17d2a7e7f168a043a2712e63aed1f8543aeafdcee47c58dcffe38ed51099
 
-# bash - v5.2.26-r0
-# bats - v1.11.0-r0
-# jq   - v1.7.1-r0
+# $ docker run --rm -it alpine:3.21.2
+# $ apk add --no-cache bash bats jq
+# $ bash --version   # => GNU bash, version 5.2.37(1)-release
+# $ bats --version   # => Bats 1.11.1
+# $ jq --version     # => jq-1.7.1
+
 RUN apk add --no-cache bash bats jq
 
 WORKDIR /opt/test-runner


### PR DESCRIPTION
Following the latest dependabot upgrade of Alpine, update the comments with the versions of relevant tools.

Also include the commands to retrieve the tool versions, for future reference 